### PR TITLE
Include types file under conditional exports in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   ],
   "types": "dist/hsluv.d.ts",
   "exports": {
+    "types": "./dist/hsluv.d.ts",
     "import": "./dist/esm/hsluv.js",
     "require": "./dist/cjs/hsluv.js"
   },


### PR DESCRIPTION
I'm not super confident in what I'm doing here, but this seems to fix a warning I was running into after trying to upgrade from 0.1.0 to 1.0.0:

> Could not find a declaration file for module 'hsluv'. 'node_modules/hsluv/dist/esm/hsluv.js' implicitly has an 'any' type.
> 
> There are types at 'node_modules/hsluv/dist/hsluv.d.ts', but this result could not be resolved when respecting package.json "exports". The 'hsluv' library may need to update its package.json or typings.ts(7016)

I can clearly see the types file defined already in package.json (a whole two lines away, totally not helping mitigate any shame or embarrassment in submitting this PR) - TypeScript even admits awareness of it - but for some mysterious reason it seems the existence of an adjacent `exports` map, uh, disqualifies it?

I'm weirdly having trouble trying to find any documentation on how this is supposed to work - the [TypeScript documentation](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html) only mentions the root level `types` key, and [Node's documentation](https://nodejs.org/api/packages.html#community-conditions-definitions) vaguely mentions that a types file should be listed first if it's included at all under `exports`

I would guess that if a package could potentially define two very different exported entrypoints, maybe one shared types file is less likely to make sense? If there's a conclusive answer for this somewhere on the internet I haven't been able to fish it out from the sea of unrelated stackoverflow questions and video tutorials about how to install pytorch on a doorbell or whatever